### PR TITLE
Notes are rendered in their correct Z-Order

### DIFF
--- a/Almost Hero/Motor2D/j1Scene.cpp
+++ b/Almost Hero/Motor2D/j1Scene.cpp
@@ -791,9 +791,9 @@ void j1Scene::HandleGameScreen(float dt) {
 	App->font->CalcSize(score_text, scoreRect.w, scoreRect.h, App->font->fonts.end->data);
 	App->render->Blit(App->font->Print(score_text, { 255,255,255,255 }, App->font->fonts.end->data), 900, 400, &scoreRect, 1, false);
 
-	p2List_item<Note*> *notes_item = notes.start;
+	p2List_item<Note*> *notes_item = notes.end;
 
-	for (; notes_item != nullptr; notes_item = notes_item->next)
+	for (; notes_item != nullptr; notes_item = notes_item->prev)
 		notes_item->data->Update(dt);
 }
 


### PR DESCRIPTION
Currently, notes are rendered in insertion order and, because no 3D graphics API is used, the notes are drawn on top of each other.
Z-Buffer is not a feasible technique to implement, it will be too slow. Instead the notes are now drawn in inverse insertion order solving the problem.
![Behaviour Comparison](https://user-images.githubusercontent.com/14297967/50577822-ea156300-0e30-11e9-93bb-8db8165a11e8.png)
Left is the previous behaviour, right is the changed behaviour.
